### PR TITLE
Added custom header support in "call" subroutine.

### DIFF
--- a/lib/OpenStack/Client.pm
+++ b/lib/OpenStack/Client.pm
@@ -179,6 +179,50 @@ body.  This method may return the following:
 
 =back
 
+=item C<$client-E<gt>call(I<$method>, I<$headers>, I<$path>, I<$body>)>
+
+There exists a second form of C<call> that allows one to pass in
+I<$headers> as an optional input parameter (hash reference), which
+allows one to directly modify the following headers sent along with
+the request; when used, I<$headers> must be placed in the second
+position after I<$method>.
+
+Headers are case I<insensitive>, and if one sets duplicate headers, one of
+them will get set; but there are no guarantess which one will. Repeat
+headers at your own risk.
+
+=over
+
+=item Accept
+
+Defaults to C<application/json, text/plain>.
+
+=item Accept-Encoding
+
+Defaults to C<identity, gzip, deflate, compress>.
+
+=item Content-Type
+
+Defaults to C<application/json>, although some API calls (e.g., a PATCH)
+expect a different type; the the case of an image update, the expected
+type is C<application/openstack-images-v2.1-json-patch> or some version
+thereof.
+
+For example, the following shows how one may update image metadata using
+the PATCH method supported by version 2 of the Image API. 
+
+In the example below, C<@image_updates> is an array of hash references of the
+structure defined by the PATCH RFC (6902) governing "JavaScript Object
+Notation (JSON) Patch"; i.e., operations consisting of C<add>, C<replace>,
+or C<delete>.
+
+  my $headers  = { 'Content-Type' => 'application/openstack-images-v2.1-json-patch' };
+  my $response = $glance->call( q{PATCH}, $headers, qq[/v2/images/$image->{id}], \@image_updates )
+
+=back
+
+And except for C<x-auth-token>, any additional token will be added to the request.
+
 In exceptional conditions (such as when the service returns a 4xx or 5xx HTTP
 response), the client will C<die()> with the raw text response from the HTTP
 service, indicating the nature of the service-side failure to service the
@@ -186,22 +230,26 @@ current call.
 
 =cut
 
-sub call ($$$$) {
-    my ($self, $method, $path, $body) = @_;
+sub call {
+    my $self = shift;
+
+    my ($method, $path, $body);
+    my $headers = {};
+
+    # if 4 arguments, $headers is in the second position after $method
+    if (scalar @_ == 4) {
+      ($method, $headers, $path, $body) = @_;
+    }
+    # original case, do not check @_ count
+    else {
+      ($method, $path, $body) = @_;
+    }
 
     my $request = $self->{'package_request'}->new(
         $method => $self->uri($path)
     );
 
-    my @headers = (
-        'Accept'          => 'application/json, text/plain',
-        'Accept-Encoding' => 'identity, gzip, deflate, compress',
-        'Content-Type'    => 'application/json'
-    );
-
-    push @headers, (
-        'X-Auth-Token' => $self->{'token'}->{'id'}
-    ) if defined $self->{'token'}->{'id'};
+    my @headers = $self->_get_headers_list($headers);
 
     my $count = scalar @headers;
 
@@ -215,6 +263,7 @@ sub call ($$$$) {
     $request->content(JSON::encode_json($body)) if defined $body;
 
     my $response = $self->{'ua'}->request($request);
+
     my $type     = $response->header('Content-Type');
     my $content  = $response->decoded_content;
 
@@ -229,6 +278,37 @@ sub call ($$$$) {
     } else {
         return $content;
     }
+}
+
+# internal method for call() to process headers; returns a list of hash references - one for each header/value
+sub _get_headers_list {
+    my ($self, $headers) = @_;
+
+    # place to store supplied headers with lowercase keys 
+    my $lc_headers = {};
+
+    # lowercase supplied headers so we know what to add in place of our default headers lc key collisions go to last set 
+    foreach my $header (keys %{$headers}) {
+        my $lc_header = lc $header;
+        $lc_headers->{$lc_header} = $headers->{$header};
+    }
+
+    # default set of headers, set defaults if not specified explicitly
+    my @headers = (
+        'Accept'          => $lc_headers->{'accept'}          // 'application/json, text/plain',
+        'Accept-Encoding' => $lc_headers->{'accept-encoding'} // 'identity, gzip, deflate, compress',
+        'Content-Type'    => $lc_headers->{'content-type'}    // 'application/json'
+    );
+
+    # add all we don't care about 
+    foreach my $header (grep( !/^Accept$|^Accept\-Encoding$|^Content\-Type$|^X-Auth-Token$/i, keys %{$lc_headers})) {
+        push @headers, $header => $lc_headers->{$header};
+    }
+
+    # client should be not adding X-Auth-Token explicitly, so force it to the one received during authentication
+    push @headers, ( 'X-Auth-Token' => $self->{'token'}->{'id'} ) if defined $self->{'token'}->{'id'};
+
+    return @headers;
 }
 
 =back
@@ -266,7 +346,7 @@ sub get ($$%) {
         # subsequent values with a & rather than ?.
         #
         if ($path =~ /\?/) {
-            $path .= "&$params"
+            $path .= "&$params";
         } else {
             $path .= "?$params";
         }


### PR DESCRIPTION
Issue-1: Call required a different header in order to use the PATCH
method of updating the properties of an image. Now, there is an
optional argument that can be passed to the call subroutine that will
allow one to specify a hash reference of headers. The only restriction
is that the "x-auth-token" header is not allowed to be modified. I also
updated the POD to reflect this change and added a basic unit test.