### PR TITLE
Add support for streaming request bodies

### DIFF
--- a/t/client.t
+++ b/t/client.t
@@ -370,6 +370,26 @@ Test::OpenStack::Client->run_client_tests({
     }
 }, {
     'responses' => [{
+        'content' => JSON::encode_json({})
+    }],
+
+    'test' => sub {
+        my ($client, $ua) = @_;
+
+        my $ran = 0;
+
+        my $sub = sub {
+            $ran = 1;
+        };
+
+        lives_ok {
+            $client->call('PUT', {}, '/foo', $sub);
+        } "\$client->call() doesn't die when passed a CODE ref request body";
+
+        is $ua->{'requests'}->[0]->{'content'} => $sub, "\$client->call() passes CODE ref request body appropriately";
+    }
+}, {
+    'responses' => [{
         'content' => JSON::encode_json({
             'items' => []
         })


### PR DESCRIPTION
Changes:

    * In OpenStack::Client->call() instance method, allow passing a
      subroutine as a request body for streaming arbitrary amounts of
      data in a request body

    * Slightly refactor the way request headers are specified and
      merged, to aid in functional clarity on how default header values,
      supplied header values, and special-use header values are handled