### PR TITLE
Implement Identity v3 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 cPanel, Inc.
+Copyright (c) 2018 cPanel, L.L.C.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/MANIFEST
+++ b/MANIFEST
@@ -6,7 +6,10 @@ README.md
 examples/images.pl
 examples/services.pl
 lib/OpenStack/Client/Auth.pm
+lib/OpenStack/Client/Auth/v2.pm
+lib/OpenStack/Client/Auth/v3.pm
 lib/OpenStack/Client.pm
+lib/OpenStack/Client/Response.pm
 t/lib/Test/OpenStack/Client.pm
 t/lib/Test/OpenStack/Client/Message.pm
 t/lib/Test/OpenStack/Client/Request.pm

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, cPanel, Inc.
+# Copyright (c) 2018, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #

--- a/README.md
+++ b/README.md
@@ -240,5 +240,5 @@ Written by Alexandra Hrefna Hilmisdóttir <xan@cpanel.net>
 
 # COPYRIGHT
 
-Copyright (c) 2015 cPanel, Inc.  Released under the terms of the MIT license.
+Copyright (c) 2018 cPanel, L.L.C.  Released under the terms of the MIT license.
 See LICENSE for further details.

--- a/examples/images.pl
+++ b/examples/images.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #

--- a/examples/services.pl
+++ b/examples/services.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #

--- a/lib/OpenStack/Client/Auth.pm
+++ b/lib/OpenStack/Client/Auth.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -89,37 +89,29 @@ for any requested OpenStack services
 sub new ($$%) {
     my ($class, $endpoint, %args) = @_;
 
-    die('No OpenStack authentication endpoint provided') unless defined $endpoint;
-    die('No OpenStack tenant name provided in "tenant"') unless defined $args{'tenant'};
-    die('No OpenStack username provided in "username"')  unless defined $args{'username'};
-    die('No OpenStack password provided in "password"')  unless defined $args{'password'};
-
-    my $client = OpenStack::Client->new($endpoint,
-        'package_ua'      => $args{'package_ua'},
-        'package_request' => $args{'package_request'}
+    my %CLASSES = (
+        '2.0' => 'OpenStack::Client::Auth::v2',
+        '3'   => 'OpenStack::Client::Auth::v3'
     );
 
-    my $response = $client->call('POST' => '/tokens', {
-        'auth' => {
-            'tenantName'          => $args{'tenant'},
-            'passwordCredentials' => {
-                'username' => $args{'username'},
-                'password' => $args{'password'}
-            }
-        }
-    });
-
-    unless (defined $response->{'access'}->{'token'}->{'id'}) {
-        die('No token found in response');
+    unless (defined $endpoint) {
+        die 'No OpenStack authentication endpoint provided';
     }
 
-    return bless {
-        'package_ua'      => $args{'package_ua'},
-        'package_request' => $args{'package_request'},
-        'response'        => $response,
-        'clients'         => {},
-        'services'        => $response->{'access'}->{'serviceCatalog'}
-    }, $class;
+    $args{'version'} ||= '2.0';
+
+    unless (defined $CLASSES{$args{'version'}}) {
+        die "Unsupported Identity endpoint version $args{'version'}";
+    }
+
+    local $@;
+
+    eval qq{
+        use $CLASSES{$args{'version'}} ();
+        1;
+    } or die $@;
+
+    return $CLASSES{$args{'version'}}->new($endpoint, %args);
 }
 
 =back
@@ -132,12 +124,6 @@ sub new ($$%) {
 
 Return the full decoded response from the Keystone API.
 
-=cut
-
-sub response ($) {
-    shift->{'response'};
-}
-
 =back
 
 =head1 ACCESSING AUTHORIZATION DATA
@@ -147,12 +133,6 @@ sub response ($) {
 =item C<$auth-E<gt>access()>
 
 Return the service access data stored in the current object.
-
-=cut
-
-sub access ($) {
-    shift->{'response'}->{'access'};
-}
 
 =back
 
@@ -164,12 +144,6 @@ sub access ($) {
 
 Return the authorization token data stored in the current object.
 
-=cut
-
-sub token ($) {
-    shift->{'response'}->{'access'}->{'token'};
-}
-
 =back
 
 =head1 OBTAINING LIST OF SERVICES AUTHORIZED
@@ -179,18 +153,6 @@ sub token ($) {
 =item C<$auth-E<gt>services()>
 
 Return a list of service types the OpenStack user is authorized to access.
-
-=cut
-
-sub services ($) {
-    my ($self) = @_;
-
-    my %types = map {
-        $_->{'type'} => 1
-    } @{$self->{'services'}};
-
-    return sort keys %types;
-}
 
 =back
 
@@ -248,57 +210,6 @@ endpoint is the public endpoint.
 
 =back
 
-=cut
-
-sub service ($$%) {
-    my ($self, $type, %opts) = @_;
-
-    if (defined $self->{'clients'}->{$type}) {
-        return  $self->{'clients'}->{$type};
-    }
-
-    if (defined $opts{'uri'}) {
-        return $self->{'clients'}->{$type} = OpenStack::Client->new($opts{'uri'},
-            'package_ua'      => $self->{'package_ua'},
-            'package_request' => $self->{'package_request'},
-            'token'           => $self->token
-        );
-    }
-
-    $opts{'endpoint'} ||= 'public';
-
-    if ($opts{'endpoint'} !~ /^(?:public|internal|admin)$/) {
-        die('Invalid endpoint type specified in "endpoint"');
-    }
-
-    foreach my $service (@{$self->{'services'}}) {
-        next unless $type eq $service->{'type'};
-
-        my $uri;
-
-        foreach my $endpoint (@{$service->{'endpoints'}}) {
-            next if defined $opts{'id'}     && $endpoint->{'id'}     ne $opts{'id'};
-            next if defined $opts{'region'} && $endpoint->{'region'} ne $opts{'region'};
-
-            if ($opts{'endpoint'} eq 'public') {
-                $uri = $endpoint->{'publicURL'};
-            } elsif ($opts{'endpoint'} eq 'internal') {
-                $uri = $endpoint->{'internalURL'};
-            } elsif ($opts{'endpoint'} eq 'admin') {
-                $uri = $endpoint->{'adminURL'};
-            }
-
-            return $self->{'clients'}->{$type} = OpenStack::Client->new($uri,
-                'package_ua'      => $self->{'package_ua'},
-                'package_request' => $self->{'package_request'},
-                'token'           => $self->token
-            );
-        }
-    }
-
-    die("No service type '$type' found");
-}
-
 =back
 
 =head1 AUTHOR
@@ -307,7 +218,7 @@ Written by Alexandra Hrefna Hilmisdóttir <xan@cpanel.net>
 
 =head1 COPYRIGHT
 
-Copyright (c) 2015 cPanel, Inc.  Released under the terms of the MIT license.
+Copyright (c) 2018 cPanel, L.L.C.  Released under the terms of the MIT license.
 See LICENSE for further details.
 
 =cut

--- a/lib/OpenStack/Client/Auth/v2.pm
+++ b/lib/OpenStack/Client/Auth/v2.pm
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2018 cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net/
+#
+# Distributed under the terms of the MIT license.  See the LICENSE file for
+# further details.
+#
+package OpenStack::Client::Auth::v2;
+
+use strict;
+use warnings;
+
+use OpenStack::Client ();
+
+sub new ($$%) {
+    my ($class, $endpoint, %args) = @_;
+
+    die 'No OpenStack tenant name provided in "tenant"' unless defined $args{'tenant'};
+    die 'No OpenStack username provided in "username"'  unless defined $args{'username'};
+    die 'No OpenStack password provided in "password"'  unless defined $args{'password'};
+
+    my $client = OpenStack::Client->new($endpoint,
+        'package_ua'       => $args{'package_ua'},
+        'package_request'  => $args{'package_request'},
+        'package_response' => $args{'package_response'}
+    );
+
+    my $response = $client->call('POST' => '/tokens', {
+        'auth' => {
+            'tenantName'          => $args{'tenant'},
+            'passwordCredentials' => {
+                'username' => $args{'username'},
+                'password' => $args{'password'}
+            }
+        }
+    });
+
+    unless (defined $response->{'access'}->{'token'}->{'id'}) {
+        die 'No token found in response';
+    }
+
+    return bless {
+        'package_ua'       => $args{'package_ua'},
+        'package_request'  => $args{'package_request'},
+        'package_response' => $args{'package_response'},
+        'response'         => $response,
+        'clients'          => {},
+        'services'         => $response->{'access'}->{'serviceCatalog'}
+    }, $class;
+}
+
+sub response ($) {
+    shift->{'response'};
+}
+
+sub access ($) {
+    shift->{'response'}->{'access'};
+}
+
+sub token ($) {
+    shift->{'response'}->{'access'}->{'token'}->{'id'};
+}
+
+sub services ($) {
+    my ($self) = @_;
+
+    my %types = map {
+        $_->{'type'} => 1
+    } @{$self->{'services'}};
+
+    return sort keys %types;
+}
+
+sub service ($$%) {
+    my ($self, $type, %opts) = @_;
+
+    if (defined $self->{'clients'}->{$type}) {
+        return  $self->{'clients'}->{$type};
+    }
+
+    if (defined $opts{'uri'}) {
+        return $self->{'clients'}->{$type} = OpenStack::Client->new($opts{'uri'},
+            'package_ua'       => $self->{'package_ua'},
+            'package_request'  => $self->{'package_request'},
+            'package_response' => $self->{'package_response'},
+            'token'            => $self->token
+        );
+    }
+
+    $opts{'endpoint'} ||= 'public';
+
+    if ($opts{'endpoint'} !~ /^(?:public|internal|admin)$/) {
+        die 'Invalid endpoint type specified in "endpoint"';
+    }
+
+    foreach my $service (@{$self->{'services'}}) {
+        next unless $type eq $service->{'type'};
+
+        my $uri;
+
+        foreach my $endpoint (@{$service->{'endpoints'}}) {
+            next if defined $opts{'id'}     && $endpoint->{'id'}     ne $opts{'id'};
+            next if defined $opts{'region'} && $endpoint->{'region'} ne $opts{'region'};
+
+            if ($opts{'endpoint'} eq 'public') {
+                $uri = $endpoint->{'publicURL'};
+            } elsif ($opts{'endpoint'} eq 'internal') {
+                $uri = $endpoint->{'internalURL'};
+            } elsif ($opts{'endpoint'} eq 'admin') {
+                $uri = $endpoint->{'adminURL'};
+            }
+
+            return $self->{'clients'}->{$type} = OpenStack::Client->new($uri,
+                'package_ua'       => $self->{'package_ua'},
+                'package_request'  => $self->{'package_request'},
+                'package_response' => $self->{'package_response'},
+                'token'            => $self->token
+            );
+        }
+    }
+
+    die "No service type '$type' found";
+}
+
+1;

--- a/lib/OpenStack/Client/Auth/v3.pm
+++ b/lib/OpenStack/Client/Auth/v3.pm
@@ -1,0 +1,149 @@
+#
+# Copyright (c) 2018 cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net/
+#
+# Distributed under the terms of the MIT license.  See the LICENSE file for
+# further details.
+#
+package OpenStack::Client::Auth::v3;
+
+use strict;
+use warnings;
+
+use OpenStack::Client ();
+
+sub new ($$%) {
+    my ($class, $endpoint, %args) = @_;
+
+    die 'No OpenStack tenant name provided in "tenant"' unless defined $args{'tenant'};
+    die 'No OpenStack username provided in "username"'  unless defined $args{'username'};
+    die 'No OpenStack password provided in "password"'  unless defined $args{'password'};
+
+    $args{'domain'} ||= 'default';
+
+    my $client = OpenStack::Client->new($endpoint,
+        'package_ua'       => $args{'package_ua'},
+        'package_request'  => $args{'package_request'},
+        'package_response' => $args{'package_response'}
+    );
+
+    my %request = (
+        'auth' => {
+            'identity' => {
+                'methods'  => [qw(password)],
+                'password' => {
+                    'user' => {
+                        'name'     => $args{'username'},
+                        'password' => $args{'password'},
+                        'domain'   => {
+                            'name' => $args{'domain'}
+                        }
+                    }
+                }
+            }
+        }
+    );
+
+    $request{'auth'}->{'scope'} = $args{'scope'} if defined $args{'scope'};
+
+    my $response = $client->request(
+        'method' => 'POST',
+        'path'   => '/auth/tokens',
+        'body'   => \%request
+    );
+
+    my $body = $response->decode_json;
+
+    unless (defined $response->header('X-Subject-Token')) {
+        die 'No token found in response headers';
+    }
+
+    unless (defined $body->{'token'}) {
+        die 'No token found in response body';
+    }
+
+    unless (defined $body->{'token'}->{'catalog'}) {
+        die 'No service catalog found in response body token';
+    }
+
+    return bless {
+        'package_ua'       => $args{'package_ua'},
+        'package_request'  => $args{'package_request'},
+        'package_response' => $args{'package_response'},
+        'response'         => $response,
+        'body'             => $body,
+        'clients'          => {},
+        'services'         => $body->{'token'}->{'catalog'}
+    }, $class;
+}
+
+sub body ($) {
+    shift->{'body'};
+}
+
+sub response ($) {
+    shift->{'response'};
+}
+
+sub access ($) {
+    shift->{'body'}->{'access'};
+}
+
+sub token ($) {
+    shift->{'response'}->header('X-Subject-Token');
+}
+
+sub services ($) {
+    my ($self) = @_;
+
+    my %types = map {
+        $_->{'type'} => 1
+    } @{$self->{'services'}};
+
+    return sort keys %types;
+}
+
+sub service ($$%) {
+    my ($self, $type, %opts) = @_;
+
+    if (defined $self->{'clients'}->{$type}) {
+        return  $self->{'clients'}->{$type};
+    }
+
+    if (defined $opts{'uri'}) {
+        return $self->{'clients'}->{$type} = OpenStack::Client->new($opts{'uri'},
+            'package_ua'       => $self->{'package_ua'},
+            'package_request'  => $self->{'package_request'},
+            'package_response' => $self->{'package_response'},
+            'token'            => $self->token
+        );
+    }
+
+    $opts{'endpoint'} ||= 'public';
+
+    if ($opts{'endpoint'} !~ /^(?:public|internal|admin)$/) {
+        die 'Invalid endpoint type specified in "endpoint"';
+    }
+
+    foreach my $service (@{$self->{'services'}}) {
+        next unless $type eq $service->{'type'};
+
+        foreach my $endpoint (@{$service->{'endpoints'}}) {
+            next if defined $opts{'id'}       && $endpoint->{'id'}        ne $opts{'id'};
+            next if defined $opts{'region'}   && $endpoint->{'region'}    ne $opts{'region'};
+            next if defined $opts{'endpoint'} && $endpoint->{'interface'} ne $opts{'endpoint'};
+
+            return $self->{'clients'}->{$type} = OpenStack::Client->new($endpoint->{'url'},
+                'package_ua'       => $self->{'package_ua'},
+                'package_request'  => $self->{'package_request'},
+                'package_response' => $self->{'package_response'},
+                'token'            => $self->token
+            );
+        }
+    }
+
+    die "No service type '$type' found";
+}
+
+1;

--- a/lib/OpenStack/Client/Response.pm
+++ b/lib/OpenStack/Client/Response.pm
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2018 cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net/
+#
+# Distributed under the terms of the MIT license.  See the LICENSE file for
+# further details.
+#
+package OpenStack::Client::Response;
+
+use strict;
+use warnings;
+
+use base 'HTTP::Response';
+
+sub decode_json {
+    my ($self) = @_;
+
+    my $type    = $self->header('Content-Type');
+    my $content = $self->decoded_content;
+
+    if ($self->code =~ /^[45]\d{2}$/) {
+        $content ||= "@{[$self->code]} Unknown error";
+
+        die $content;
+    }
+
+    if (defined $content && length $content) {
+        if (lc($type) =~ qr{^application/json}i) {
+            return JSON::decode_json($content);
+        }
+    }
+
+    return $content;
+}
+
+1;

--- a/t/auth.t
+++ b/t/auth.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -29,26 +29,186 @@ my %test_credentials = (
     'password' => 'bar'
 );
 
+my @test_versions = (
+    undef, '2.0', 3
+);
+
 throws_ok {
     OpenStack::Client::Auth->new()
 } qr/No OpenStack authentication endpoint provided/, "OpenStack::Client::Auth->new() dies if no endpoint is provided";
 
-throws_ok {
-    OpenStack::Client::Auth->new($test_endpoint);
-} qr/No OpenStack tenant name provided in "tenant"/, "OpenStack::Client::Auth->new() dies if no tenant name is provided";
+foreach my $test_version (@test_versions) {
+    my $version = defined $test_version? $test_version: 'undefined';
+
+    throws_ok {
+        OpenStack::Client::Auth->new($test_endpoint,
+            (defined $test_version? ('version' => $test_version): ()),
+        );
+    } qr/No OpenStack tenant name provided in "tenant"/, "OpenStack::Client::Auth->new() dies if no tenant name is provided for version $version";
+
+    throws_ok {
+        OpenStack::Client::Auth->new($test_endpoint,
+            (defined $test_version? ('version' => $test_version): ()),
+            'tenant' => $test_credentials{'tenant'}
+        );
+    } qr/No OpenStack username provided in "username"/, "OpenStack::Client::Auth->new() dies if no username is provided for version $version";
+
+    throws_ok {
+        OpenStack::Client::Auth->new($test_endpoint,
+            (defined $test_version? ('version' => $test_version): ()),
+            'tenant'   => $test_credentials{'tenant'},
+            'username' => $test_credentials{'username'}
+        );
+    } qr/No OpenStack password provided in "password"/, "OpenStack::Client::Auth->new() dies if no password is provided for version $version";
+}
 
 throws_ok {
-    OpenStack::Client::Auth->new($test_endpoint,
-        'tenant' => $test_credentials{'tenant'}
+    OpenStack::Client::Auth->new($test_endpoint, %test_credentials,
+        'version' => 'poop'
     );
-} qr/No OpenStack username provided in "username"/, "OpenStack::Client::Auth->new() dies if no username is provided";
+} qr/Unsupported Identity endpoint version poop/, "OpenStack::Client::Auth->new() dies if invalid version is provided";
 
-throws_ok {
-    OpenStack::Client::Auth->new($test_endpoint,
-        'tenant'   => $test_credentials{'tenant'},
-        'username' => $test_credentials{'username'}
-    );
-} qr/No OpenStack password provided in "password"/, "OpenStack::Client::Auth->new() dies if no password is provided";
+my $full_content_v3 = JSON::encode_json({
+    'token' => {
+        'audit_ids' => ['3T2dc1CGQxyJsHdDu1xkcw'],
+        'catalog'   => [
+            {
+                'endpoints' => [
+                    {   'id'        => 'cafebabe',
+                        'interface' => 'public',
+                        'region'    => 'Morocco',
+                        'region_id' => 'Morocco',
+                        'url'       => 'http://example.com/public/image/v2'
+                    },
+                    {   'id'        => '8bfc846841ab441ca38471be6d164ced',
+                        'interface' => 'admin',
+                        'region'    => 'Morocco',
+                        'region_id' => 'Morocco',
+                        'url'       => 'http://example.com/admin/image/v2'
+                    },
+                    {   'id'        => 'beb6d358c3654b4bada04d4663b640b9',
+                        'interface' => 'internal',
+                        'region'    => 'Morocco',
+                        'region_id' => 'Morocco',
+                        'url'       => 'http://example.com/internal/image/v2'
+                    }
+                ],
+                'id'   => '050726f278654128aba89757ae25950c',
+                'name' => 'glance',
+                'type' => 'image'
+            }
+        ],
+        'expires_at' => '2015-11-07T02 =>58 =>43.578887Z',
+        'issued_at'  => '2015-11-07T01 =>58 =>43.578929Z',
+        'methods'    => ['password'],
+        'roles'      => [
+            {   'id'   => '51cc68287d524c759f47c811e6463340',
+                'name' => 'admin'
+            }
+        ],
+        'system' => {'all' => JSON::true},
+        'user'   => {
+            'domain' => {
+                'id'   => 'default',
+                'name' => 'Default'
+            },
+            'id'                  => 'ee4dfb6e5540447cb3741905149d9b6e',
+            'name'                => 'admin',
+            'password_expires_at' => '2016-11-06T15 =>32 =>17.000000'
+        }
+    }
+});
+
+Test::OpenStack::Client->run_client_tests({
+    'responses' => [{
+        'content' => $full_content_v3,
+        'headers' => {
+            'X-Subject-Token' => 'foobarbaz'
+        }
+    }],
+
+    'test' => sub {
+        my ($client, $ua) = @_;
+
+        my $auth;
+        
+        lives_ok {
+            $auth = OpenStack::Client::Auth->new($test_endpoint,
+                %test_credentials,
+                'version'          => '3',
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
+            );
+        } "OpenStack::Client::Auth->new() doesn't die with 'version' => '3'";
+
+        like ref($auth) => qr/^OpenStack::Client::Auth::v3/,
+            "OpenStack::Client::Auth->new() will use Identity v3 when asked";
+    }
+}, {
+    'responses' => [{
+        'content' => '{}',
+    }, {
+        'headers' => {
+            'X-Subject-Token' => 'foobarbaz'
+        },
+        'content' => '{}'
+    }, {
+        'headers' => {
+            'X-Subject-Token' => 'foobarbaz'
+        },
+        'content' => '{"token":{}}'
+    }, {
+        'headers' => {
+            'X-Subject-Token' => 'foobarbaz'
+        },
+        'content' => '{"token":{"catalog":[]}}'
+    }],
+
+    'test' => sub {
+        my ($client, $ua) = @_;
+
+        throws_ok {
+            OpenStack::Client::Auth->new($test_endpoint,
+                %test_credentials,
+                'version'          => '3',
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
+            );
+        } qr/No token found in response headers/, "OpenStack::Client::Auth->new() dies when no token found in response headers for v3";
+
+        throws_ok {
+            OpenStack::Client::Auth->new($test_endpoint,
+                %test_credentials,
+                'version'          => '3',
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
+            );
+        } qr/No token found in response body/, "OpenStack::Client::Auth->new() dies when no token found in response body for v3";
+
+        throws_ok {
+            OpenStack::Client::Auth->new($test_endpoint,
+                %test_credentials,
+                'version'          => '3',
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
+            );
+        } qr/No service catalog found in response body token/, "OpenStack::Client::Auth->new() dies when no service catalog found in response body token for v3";
+
+        lives_ok {
+            OpenStack::Client::Auth->new($test_endpoint,
+                %test_credentials,
+                'version'          => '3',
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
+            );
+        } "OpenStack::Client::Auth->new() lives when service catalog is found in response body token for v3";
+    }
+});
 
 Test::OpenStack::Client->run_client_tests({
     'responses' => [{
@@ -60,14 +220,15 @@ Test::OpenStack::Client->run_client_tests({
 
         throws_ok {
             OpenStack::Client::Auth->new($test_endpoint, %test_credentials,
-                'package_ua'      => $ua,
-                'package_request' => 'Test::OpenStack::Client::Request'
+                'package_ua'       => $ua,
+                'package_request'  => 'Test::OpenStack::Client::Request',
+                'package_response' => 'Test::OpenStack::Client::Response'
             );
-        } qr/No token found in response/, "OpenStack::Client::Auth->new() dies when service does not return authorization token";
+        } qr/No token found in response/, "OpenStack::Client::Auth->new() dies when service does not return authorization token for v2";
     }
 });
 
-my $full_content = JSON::encode_json({
+my $full_content_v2 = JSON::encode_json({
     'access' => {
         'token' => {
             'id' => 'abc123'
@@ -95,13 +256,14 @@ my $full_content = JSON::encode_json({
     },
 });
 
-Test::OpenStack::Client->run_auth_tests({
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+Test::OpenStack::Client->run_auth_tests(
+    'version' => '2.0',
+    'content' => $full_content_v2,
+    'tests'   => [sub {
         my ($auth, $ua) = @_;
+
+        like ref($auth) => qr/^OpenStack::Client::Auth::v2/,
+            'OpenStack::Client::Auth->new() defaults to Identity v2';
 
         throws_ok {
             $auth->service('image',
@@ -150,7 +312,7 @@ Test::OpenStack::Client->run_auth_tests({
 
         {
             my $got      = $auth->token;
-            my $expected = $content->{'access'}->{'token'};
+            my $expected = $content->{'access'}->{'token'}->{'id'};
 
             is_deeply($got => $expected, "\$auth->token() returns authorization token from response body as expected");
         }
@@ -168,13 +330,7 @@ Test::OpenStack::Client->run_auth_tests({
 
             is($got => $expected, "\$auth->service() returns a cached client object across calls");
         }
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -182,7 +338,7 @@ Test::OpenStack::Client->run_auth_tests({
         );
 
         my $got      = $client->endpoint;
-        my $expected = JSON::decode_json($full_content)
+        my $expected = JSON::decode_json($full_content_v2)
             ->{'access'}
             ->{'serviceCatalog'}
             ->[0]
@@ -191,13 +347,7 @@ Test::OpenStack::Client->run_auth_tests({
             ->{'publicURL'};
 
         is($got => $expected, "\$auth->service() returns client for public endpoint when requested");
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -205,7 +355,7 @@ Test::OpenStack::Client->run_auth_tests({
         );
 
         my $got      = $client->endpoint;
-        my $expected = JSON::decode_json($full_content)
+        my $expected = JSON::decode_json($full_content_v2)
             ->{'access'}
             ->{'serviceCatalog'}
             ->[0]
@@ -214,13 +364,7 @@ Test::OpenStack::Client->run_auth_tests({
             ->{'adminURL'};
 
         is($got => $expected, "\$auth->service() returns client for admin endpoint when requested");
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -228,7 +372,7 @@ Test::OpenStack::Client->run_auth_tests({
         );
 
         my $got      = $client->endpoint;
-        my $expected = JSON::decode_json($full_content)
+        my $expected = JSON::decode_json($full_content_v2)
             ->{'access'}
             ->{'serviceCatalog'}
             ->[0]
@@ -237,13 +381,7 @@ Test::OpenStack::Client->run_auth_tests({
             ->{'internalURL'};
 
         is($got => $expected, "\$auth->service() returns client for internal endpoint when requested");
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -254,13 +392,7 @@ Test::OpenStack::Client->run_auth_tests({
         my $expected = 'http://meow.cats/';
 
         is($got => $expected, "\$auth->service() returns client for an endpoint whose URI is explicitly provided");
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -271,13 +403,7 @@ Test::OpenStack::Client->run_auth_tests({
         my $expected = 'http://meow.cats/public/image/v2';
 
         is ($got => $expected, "\$auth->service() returns client for an endpoint whose ID is specified");
-    }
-}, {
-    'responses' => [{
-        'content' => $full_content
-    }],
-
-    'test' => sub {
+    }, sub {
         my ($auth, $ua) = @_;
 
         my $client = $auth->service('image',
@@ -289,4 +415,151 @@ Test::OpenStack::Client->run_auth_tests({
 
         is ($got => $expected, "\$auth->service() returns client for an endpoint whose region is specified");
     }
-});
+]);
+
+Test::OpenStack::Client->run_auth_tests(
+    'version' => '3',
+    'headers' => {
+        'X-Subject-Token' => 'foobarbaz'
+    },
+    'content' => $full_content_v3,
+    'tests'   => [sub {
+        my ($auth, $ua) = @_;
+
+        my $content = JSON::decode_json($ua->{'responses'}->[0]->content);
+
+        throws_ok {
+            $auth->service('foo');
+        } qr/No service type 'foo' found/, "\$auth->service() dies when asked to return a client for a service that does not exist";
+
+        lives_ok {
+            $auth->service('image');
+        } "\$auth->service() doesn't die when expected to return client for default endpoint for requested service";
+
+        {
+            my $got = JSON::decode_json($ua->{'requests'}->[0]->content);
+
+            ok defined($got->{'auth'}->{'identity'}->{'password'}),
+                "OpenStack::Client::Auth->new() issues an HTTP request to a Keystone endpoint with expected credentials for v3";
+        }
+
+        {
+            my $got      = $auth->response->decode_json;
+            my $expected = $content;
+
+            is_deeply($got => $expected, "\$auth->response() returns whole authentication response body as expected");
+        }
+
+        {
+            my $got      = $auth->access;
+            my $expected = $content->{'access'};
+
+            is_deeply($got => $expected, "\$auth->access() returns systems access data from authentication response body as expected");
+        }
+
+        {
+            my $got      = $auth->token;
+            my $expected = $ua->{'responses'}->[0]->header('X-Subject-Token');
+
+            is_deeply($got => $expected, "\$auth->token() returns authorization token from response body as expected");
+        }
+
+        {
+            my @got      = $auth->services;
+            my @expected = qw(image);
+
+            is_deeply(\@got => \@expected, "\$auth->services() returns list of service types as expected");
+        }
+
+        {
+            my $got      = $auth->service('image');
+            my $expected = $auth->service('image');
+
+            is($got => $expected, "\$auth->service() returns a cached client object across calls");
+        }
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'endpoint' => 'public'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = JSON::decode_json($full_content_v3)
+            ->{'token'}
+            ->{'catalog'}
+            ->[0]
+            ->{'endpoints'}
+            ->[0]
+            ->{'url'};
+
+        is($got => $expected, "\$auth->service() returns client for public endpoint when requested");
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'endpoint' => 'admin'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = JSON::decode_json($full_content_v3)
+            ->{'token'}
+            ->{'catalog'}
+            ->[0]
+            ->{'endpoints'}
+            ->[1]
+            ->{'url'};
+
+        is($got => $expected, "\$auth->service() returns client for admin endpoint when requested");
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'endpoint' => 'internal'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = JSON::decode_json($full_content_v3)
+            ->{'token'}
+            ->{'catalog'}
+            ->[0]
+            ->{'endpoints'}
+            ->[2]
+            ->{'url'};
+
+        is($got => $expected, "\$auth->service() returns client for internal endpoint when requested");
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'uri' => 'http://example.com/identity'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = 'http://example.com/identity';
+
+        is($got => $expected, "\$auth->service() returns client for an endpoint whose URI is explicitly provided");
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'id' => 'cafebabe'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = 'http://example.com/public/image/v2';
+
+        is ($got => $expected, "\$auth->service() returns client for an endpoint whose ID is specified");
+    }, sub {
+        my ($auth, $ua) = @_;
+
+        my $client = $auth->service('image',
+            'region' => 'Morocco'
+        );
+
+        my $got      = $client->endpoint;
+        my $expected = 'http://example.com/public/image/v2';
+
+        is ($got => $expected, "\$auth->service() returns client for an endpoint whose region is specified");
+    }
+]);

--- a/t/client.t
+++ b/t/client.t
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -10,8 +10,6 @@
 
 use strict;
 use warnings;
-
-use Carp;
 
 use OpenStack::Client ();
 

--- a/t/lib/Test/OpenStack/Client.pm
+++ b/t/lib/Test/OpenStack/Client.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -36,8 +36,9 @@ sub run_client_tests ($@) {
         );
 
         my $client = OpenStack::Client->new($endpoint,
-            'package_ua'      => $ua,
-            'package_request' => 'Test::OpenStack::Client::Request'
+            'package_ua'       => $ua,
+            'package_request'  => 'Test::OpenStack::Client::Request',
+            'package_response' => 'Test::OpenStack::Client::Response'
         );
 
         $test->{'test'}->($client, $ua);
@@ -47,36 +48,31 @@ sub run_client_tests ($@) {
 }
 
 sub run_auth_tests ($@) {
-    my ($class, @tests) = @_;
+    my ($class, %args) = @_;
 
-    foreach my $test (@tests) {
-        my $endpoint    = $test->{'endpoint'}    || 'http://foo.bar/';
-        my $credentials = $test->{'credentials'} || {
-            'tenant'   => 'foo',
-            'username' => 'foo',
-            'password' => 'bar'
-        };
+    my $endpoint    = 'http://foo.bar/';
+    my $credentials = {
+        'tenant'   => 'foo',
+        'username' => 'foo',
+        'password' => 'bar'
+    };
 
-        my @responses;
-
-        push @responses, map {
-            Test::OpenStack::Client::Response->new(%{$_})
-        } @{$test->{'responses'}} if defined $test->{'responses'};
-
-        unless (@responses) {
-            push @responses, Test::OpenStack::Client::Response->new;
-        }
-
+    foreach my $test (@{$args{'tests'}}) {
         my $ua = Test::OpenStack::Client::UserAgent->generate(
-            'responses' => \@responses
+            'responses' => [Test::OpenStack::Client::Response->new(
+                'headers' => $args{'headers'},
+                'content' => $args{'content'}
+            )]
         );
 
         my $auth = OpenStack::Client::Auth->new($endpoint, %{$credentials},
-            'package_ua'      => $ua,
-            'package_request' => 'Test::OpenStack::Client::Request'
+            'version'          => $args{'version'},
+            'package_ua'       => $ua,
+            'package_request'  => 'Test::OpenStack::Client::Request',
+            'package_response' => 'Test::OpenStack::Client::Response'
         );
 
-        $test->{'test'}->($auth, $ua);
+        $test->($auth, $ua);
     }
 
     return;

--- a/t/lib/Test/OpenStack/Client/Message.pm
+++ b/t/lib/Test/OpenStack/Client/Message.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #

--- a/t/lib/Test/OpenStack/Client/Request.pm
+++ b/t/lib/Test/OpenStack/Client/Request.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -18,8 +18,8 @@ our @ISA = qw(Test::OpenStack::Client::Message);
 sub new ($%) {
     my ($class, $method, $path) = @_;
 
-    Carp::croak('No HTTP method provided')       unless defined $method;
-    Carp::croak('No HTTP request path provided') unless defined $path;
+    die 'No HTTP method provided'       unless defined $method;
+    die 'No HTTP request path provided' unless defined $path;
 
     return bless $class->SUPER::new(
         'method' => $method,

--- a/t/lib/Test/OpenStack/Client/Response.pm
+++ b/t/lib/Test/OpenStack/Client/Response.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #
@@ -11,9 +11,7 @@ package Test::OpenStack::Client::Response;
 use strict;
 use warnings;
 
-use Test::OpenStack::Client::Message ();
-
-our @ISA = qw(Test::OpenStack::Client::Message);
+use base qw(Test::OpenStack::Client::Message OpenStack::Client::Response);
 
 sub new ($%) {
     my ($class, %opts) = @_;

--- a/t/lib/Test/OpenStack/Client/UserAgent.pm
+++ b/t/lib/Test/OpenStack/Client/UserAgent.pm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 cPanel, Inc.
+# Copyright (c) 2018 cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net/
 #


### PR DESCRIPTION
Changes:

    * Move Identity v2 authentication code into new module,
      OpenStack::Client::Auth::v2

    * Add Identity v3 authentication support in new module,
      OpenStack::Client::Auth::v3

    * Refactor OpenStack::Client::Auth to delegate authentication
      requests to appropriate module based on requested Identity API
      version

    * Move response body decoding responsibilities to
      OpenStack::Client::Response

    * Rework tests to accommodate injection of
      Test::OpenStack::Client::Response usage

    * Rework tests to exercise Identity v2 and v3 clients

    * Remove usage of Carp in tests in favor of allowing the invoker to
      use Carp::Always when needed

    * Small stylistic tweaks