### PR TITLE
Tenant should not be mandatory for auth::v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: perl
+perl:
+  # - "5.8.8"
+  # - "5.8"
+  # - "5.10"
+  # - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "blead"
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - perl: 5.26
+      env: COVERAGE=1
+  allow_failures:
+    - perl: blead
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto
+branches:
+  except:
+    - /^wip\//
+    - /^blocked/
+    - /^issue\d+/
+    - /^gh\d+/

--- a/lib/OpenStack/Client/Auth.pm
+++ b/lib/OpenStack/Client/Auth.pm
@@ -29,6 +29,14 @@ OpenStack::Client::Auth - OpenStack Keystone authentication and authorization
         'password' => $ENV{'OS_PASSWORD'}
     );
 
+    # or you can also use API v3
+    $auth = OpenStack::Client::Auth->new(
+        $ENV{OS_AUTH_URL},
+        'username' => $ENV{'OS_USERNAME'},
+        'password' => $ENV{'OS_PASSWORD'},
+        'version'  => 3
+    );
+
     my $glance = $auth->service('image',
         'region' => $ENV{'OS_REGION_NAME'}
     );

--- a/lib/OpenStack/Client/Auth/v3.pm
+++ b/lib/OpenStack/Client/Auth/v3.pm
@@ -16,7 +16,6 @@ use OpenStack::Client ();
 sub new ($$%) {
     my ($class, $endpoint, %args) = @_;
 
-    die 'No OpenStack tenant name provided in "tenant"' unless defined $args{'tenant'};
     die 'No OpenStack username provided in "username"'  unless defined $args{'username'};
     die 'No OpenStack password provided in "password"'  unless defined $args{'password'};
 

--- a/t/auth.t
+++ b/t/auth.t
@@ -40,11 +40,13 @@ throws_ok {
 foreach my $test_version (@test_versions) {
     my $version = defined $test_version? $test_version: 'undefined';
 
-    throws_ok {
-        OpenStack::Client::Auth->new($test_endpoint,
-            (defined $test_version? ('version' => $test_version): ()),
-        );
-    } qr/No OpenStack tenant name provided in "tenant"/, "OpenStack::Client::Auth->new() dies if no tenant name is provided for version $version";
+    if ( $test_version && $test_version < 3 ) {
+        throws_ok {
+            OpenStack::Client::Auth->new($test_endpoint,
+                (defined $test_version? ('version' => $test_version): ()),
+            );
+        } qr/No OpenStack tenant name provided in "tenant"/, "OpenStack::Client::Auth->new() dies if no tenant name is provided for version $version";
+    }
 
     throws_ok {
         OpenStack::Client::Auth->new($test_endpoint,


### PR DESCRIPTION
this PR also contains the travis change so I can confirm the change is ok
https://travis-ci.org/atoomic/OpenStack-Client/builds/518936651
