### PR TITLE
Improve error message when missing attribute

### DIFF
--- a/lib/OpenStack/Client.pm
+++ b/lib/OpenStack/Client.pm
@@ -515,7 +515,8 @@ sub every ($$$@) {
         my $result = $self->get($path, %{$opts});
 
         unless (defined $result->{$attribute}) {
-            die "Response from $path does not contain attribute '$attribute'";
+            my $keys = join( ', ', sort keys %$result );
+            die "Response from $path does not contain attribute '$attribute', possible options are " . $keys;
         }
 
         foreach my $item (@{$result->{$attribute}}) {


### PR DESCRIPTION
When we are using an invalid key to read the
reply from the API, list the alternate
options to fixup the typo.