### PR TITLE
Fix runtime dependencies list

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
     'ABSTRACT'         => 'A nice and tiny OpenStack API client',
     'MIN_PERL_VERSION' => '5.14.0',
 
-    'BUILD_REQUIRES' => {
+    'PREREQ_PM' => {
         'JSON'           => 0,
         'HTTP::Request'  => 0,
         'LWP::UserAgent' => 0,


### PR DESCRIPTION
OpenStack::Client requires these modules
at run time. The dependencies are not only
used for building the module but also to use
it.